### PR TITLE
Improved Settings class 

### DIFF
--- a/Settings.php
+++ b/Settings.php
@@ -28,10 +28,10 @@ class Settings
 
     public function __construct()
     {
-        $this->environmentSettings();
+        $this->initEnvironmentSettings();
     }
 
-    public function environmentSettings()
+    public function initEnvironmentSettings()
     {
         $this->UserCode = "";
         $this->Pin = "";

--- a/Settings.php
+++ b/Settings.php
@@ -4,62 +4,39 @@
 Tüm çağrılarda kullanılacak olan ayarların tutulduğu kısımdır.
 */
 class Settings
-{      
-    public function Settings()
-    {
-    	$environment = $this->Environment."Environments";
-        $this->{$environment}();
-    }
-    private function TestEnvironments()
-    {
-    	/**
-    	 * Wirecard tarafından sizlere verilen Test User Code bilgisi
-    	 */
-    	
-    	$this->UserCode = "";
-    	/**
-    	 * Wirecard tarafından sizlere verilen Test Pin bilgisi
-    	 */
-        $this->Pin = "";
+{
 
-        /**
-         * Wirecard web servisleri Test API ucu
-         */
-        $this->BaseUrl="https://test.3pay.com/sgate/Gate";
-		/**
-		*Wirecard tarafından sizlere verilen Private HashKey bilgisi
-		*/ 
-		$this->HashKey="";
-    }
-    private function ProductionEnvironments()
-    {
-    	/**
-    	 * Wirecard tarafından sizlere verilen Test User Code bilgisi
-    	 */
-    	
-    	$this->UserCode = "";
-    	/**
-    	 * Wirecard tarafından sizlere verilen Test Pin bilgisi
-    	 */
-        $this->Pin = "";
-
-        /**
-         * Wirecard web servisleri Test API ucu
-         */
-        $this->BaseUrl="https://www.wirecard.com.tr/SGate/Gate";
-		/**
-		*Wirecard tarafından sizlere verilen Private HashKey bilgisi
-		*/ 
-		$this->HashKey="";
-    }
-    public $UserCode;
-    public $Pin;
-    public $BaseUrl;
-	public $HashKey;
     /**
-     * Test ortamında işlem yapıyorsanız, bu değişkenin değeri Test olmalıdır.
-     * Canlı ortamda işlem yapıyorsanız, bu değişkenin değeri Production olmalıdır.
+     * Wirecard tarafından sizlere verilen Test User Code bilgisi
      */
-    public $Environment = 'Production';
-    
+    public $UserCode;
+
+    /**
+     * Wirecard tarafından sizlere verilen Test Pin bilgisi
+     */
+    public $Pin;
+
+    /**
+     * Wirecard web servisleri Test API ucu
+     */
+    public $BaseUrl;
+
+    /**
+     *Wirecard tarafından sizlere verilen Private HashKey bilgisi
+     */
+    public $HashKey;
+
+    public function __construct()
+    {
+        $this->environmentSettings();
+    }
+
+    public function environmentSettings()
+    {
+        $this->UserCode = "";
+        $this->Pin = "";
+        $this->BaseUrl="https://www.wirecard.com.tr/SGate/Gate";
+        $this->HashKey="";
+    }
+
 }

--- a/SettingsTest.php
+++ b/SettingsTest.php
@@ -3,7 +3,7 @@
 class SettingsTest extends Settings
 {
 
-    public function environmentSettings()
+    public function initEnvironmentSettings()
     {
         $this->UserCode = "";
         $this->Pin = "";

--- a/SettingsTest.php
+++ b/SettingsTest.php
@@ -1,0 +1,14 @@
+<?php
+
+class SettingsTest extends Settings
+{
+
+    public function environmentSettings()
+    {
+        $this->UserCode = "";
+        $this->Pin = "";
+        $this->BaseUrl="https://test.3pay.com/sgate/Gate";
+        $this->HashKey="";
+    }
+
+}


### PR DESCRIPTION
"Old style constructors are DEPRECATED in PHP 7.0, and will be removed in a future version. You should always use __construct() in new code. "

https://www.php.net/manual/en/language.oop5.decon.php